### PR TITLE
Add dashboard for managing profile and saved logos

### DIFF
--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -1,0 +1,387 @@
+<template>
+    <section class="dashboard-page w-full min-h-screen bg-neutral-50 font-primary py-[80px]">
+        <div class="max-w-5xl mx-auto px-6 lg:px-8">
+            <header class="mb-10">
+                <h1 class="text-[34px] md:text-[42px] font-black text-black leading-[1.1] mb-4 uppercase">
+                    Account Dashboard
+                </h1>
+                <p class="text-neutral-600 text-[18px] md:text-[20px] leading-[1.5] max-w-3xl">
+                    Review and update your contact details, then jump back into any logo concepts you saved while building.
+                </p>
+            </header>
+
+            <div v-if="isAuthChecking" class="bg-white border border-neutral-200 rounded-[16px] shadow-sm p-8 text-center">
+                <p class="text-neutral-600 text-[18px] font-medium">Checking your account details...</p>
+            </div>
+
+            <div v-else-if="!currentUser" class="bg-white border border-neutral-200 rounded-[16px] shadow-sm p-8">
+                <h2 class="text-[24px] font-bold text-black mb-3">You're almost there</h2>
+                <p class="text-neutral-600 text-[18px] leading-[1.5]">
+                    Sign in to access your dashboard, update your information, and keep all of your saved logo progress in one place.
+                </p>
+            </div>
+
+            <div v-else class="space-y-12">
+                <section class="bg-white border border-neutral-200 rounded-[20px] shadow-sm overflow-hidden">
+                    <div class="px-6 md:px-10 py-6 border-b border-neutral-200 bg-neutral-100">
+                        <h2 class="text-[26px] md:text-[30px] font-black text-black uppercase">Profile Details</h2>
+                        <p class="text-neutral-600 text-[16px] md:text-[18px] leading-[1.5]">
+                            Update the information we use when contacting you about your designs or delivering finished files.
+                        </p>
+                    </div>
+                    <form class="px-6 md:px-10 py-8 space-y-8" @submit.prevent="handleSave">
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div class="flex flex-col">
+                                <label for="firstName" class="text-[15px] font-semibold text-neutral-700 mb-2 uppercase tracking-[1px]">
+                                    First Name
+                                </label>
+                                <input
+                                    id="firstName"
+                                    v-model="form.firstName"
+                                    type="text"
+                                    autocomplete="given-name"
+                                    class="rounded-[10px] border border-neutral-300 focus:border-brand-300 focus:ring-0 text-[16px] text-neutral-900 px-4 py-3 disabled:bg-neutral-100 disabled:text-neutral-400"
+                                    placeholder="John"
+                                    :disabled="isLoadingProfile || isAuthChecking || isSaving"
+                                />
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="lastName" class="text-[15px] font-semibold text-neutral-700 mb-2 uppercase tracking-[1px]">
+                                    Last Name
+                                </label>
+                                <input
+                                    id="lastName"
+                                    v-model="form.lastName"
+                                    type="text"
+                                    autocomplete="family-name"
+                                    class="rounded-[10px] border border-neutral-300 focus:border-brand-300 focus:ring-0 text-[16px] text-neutral-900 px-4 py-3 disabled:bg-neutral-100 disabled:text-neutral-400"
+                                    placeholder="Doe"
+                                    :disabled="isLoadingProfile || isAuthChecking || isSaving"
+                                />
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="phone" class="text-[15px] font-semibold text-neutral-700 mb-2 uppercase tracking-[1px]">
+                                    Phone
+                                </label>
+                                <input
+                                    id="phone"
+                                    v-model="form.phone"
+                                    type="tel"
+                                    autocomplete="tel"
+                                    class="rounded-[10px] border border-neutral-300 focus:border-brand-300 focus:ring-0 text-[16px] text-neutral-900 px-4 py-3 disabled:bg-neutral-100 disabled:text-neutral-400"
+                                    placeholder="(555) 123-4567"
+                                    :disabled="isLoadingProfile || isAuthChecking || isSaving"
+                                />
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="email" class="text-[15px] font-semibold text-neutral-700 mb-2 uppercase tracking-[1px]">
+                                    Email
+                                </label>
+                                <input
+                                    id="email"
+                                    v-model="form.email"
+                                    type="email"
+                                    autocomplete="email"
+                                    class="rounded-[10px] border border-neutral-300 focus:border-brand-300 focus:ring-0 text-[16px] text-neutral-900 px-4 py-3 disabled:bg-neutral-100 disabled:text-neutral-400"
+                                    placeholder="you@example.com"
+                                    :disabled="isLoadingProfile || isAuthChecking || isSaving"
+                                />
+                            </div>
+                        </div>
+
+                        <div class="space-y-3">
+                            <p
+                                v-if="profileError"
+                                class="bg-red-50 border border-red-200 text-red-600 text-[16px] font-medium px-4 py-3 rounded-[10px]"
+                            >
+                                {{ profileError }}
+                            </p>
+                            <p
+                                v-if="feedback.success"
+                                class="bg-green-50 border border-green-200 text-green-700 text-[16px] font-medium px-4 py-3 rounded-[10px]"
+                            >
+                                {{ feedback.success }}
+                            </p>
+                        </div>
+
+                        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                            <p v-if="lastSavedCopy" class="text-[14px] text-neutral-500">
+                                Last saved {{ lastSavedCopy }}
+                            </p>
+                            <button
+                                type="submit"
+                                class="cta-btn bg-brand-300 text-white uppercase font-black tracking-[2px] text-[16px] leading-[1] py-4 px-6 rounded-[10px] transition transition-fast hover:bg-brand-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                                :disabled="isSaving || isLoadingProfile || isAuthChecking || !hasChanges"
+                            >
+                                <span v-if="isSaving">Saving...</span>
+                                <span v-else>Save Changes</span>
+                            </button>
+                        </div>
+                    </form>
+                </section>
+
+                <section class="bg-white border border-neutral-200 rounded-[20px] shadow-sm overflow-hidden">
+                    <div class="px-6 md:px-10 py-6 border-b border-neutral-200 bg-neutral-100">
+                        <h2 class="text-[26px] md:text-[30px] font-black text-black uppercase">Saved Logos</h2>
+                        <p class="text-neutral-600 text-[16px] md:text-[18px] leading-[1.5]">
+                            Revisit any concept you saved. Restoring a logo sends you right back into the builder with the same settings.
+                        </p>
+                    </div>
+                    <div class="px-6 md:px-10 py-8 space-y-6">
+                        <div v-if="logosLoading" class="text-neutral-600 text-[18px] font-medium">Loading saved logos...</div>
+                        <div v-else-if="!formattedLogos.length" class="text-neutral-600 text-[18px] font-medium">
+                            You haven't saved any logos yet. Generate designs and save your favorites to see them here.
+                        </div>
+                        <div v-else class="grid gap-6">
+                            <article
+                                v-for="logo in formattedLogos"
+                                :key="logo.id"
+                                class="border border-neutral-200 rounded-[16px] p-6 bg-neutral-50"
+                            >
+                                <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                                    <div class="space-y-2">
+                                        <h3 class="text-[20px] font-bold text-black leading-[1.2]">
+                                            {{ getLogoTitle(logo) }}
+                                        </h3>
+                                        <p class="text-[14px] text-neutral-500">
+                                            Saved {{ formatDisplayDate(logo.createdAtDate) }}
+                                        </p>
+                                        <p v-if="logo.state?.selectedLogoID" class="text-[14px] text-neutral-500">
+                                            Logo ID: {{ logo.state.selectedLogoID }}
+                                        </p>
+                                        <p v-if="logo.state?.businessCategory" class="text-[14px] text-neutral-500">
+                                            Category: {{ logo.state.businessCategory }}
+                                        </p>
+                                        <p v-if="logo.state?.selectedIndustry" class="text-[14px] text-neutral-500">
+                                            Industry: {{ logo.state.selectedIndustry?.name || logo.state.selectedIndustry }}
+                                        </p>
+                                        <div v-if="logo.state?.selectedColorStyles?.length" class="flex flex-wrap gap-2 pt-1">
+                                            <span
+                                                v-for="(color, index) in logo.state.selectedColorStyles"
+                                                :key="`${logo.id}-color-${index}`"
+                                                class="px-3 py-1 rounded-full bg-white border border-neutral-200 text-[13px] text-neutral-600"
+                                            >
+                                                {{ color?.name || color }}
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <div class="flex flex-col items-stretch gap-3 min-w-[180px]">
+                                        <button
+                                            type="button"
+                                            class="cta-btn bg-brand-300 text-white uppercase font-black tracking-[2px] text-[14px] leading-[1] py-3 px-4 rounded-[10px] transition transition-fast hover:bg-brand-200"
+                                            @click="resumeLogo(logo)"
+                                        >
+                                            Resume Editing
+                                        </button>
+                                        <button
+                                            type="button"
+                                            class="text-brand-300 font-bold text-[14px] underline"
+                                            @click="exportLogoState(logo)"
+                                        >
+                                            Download Settings
+                                        </button>
+                                    </div>
+                                </div>
+                            </article>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </div>
+    </section>
+</template>
+
+<script setup>
+import { computed, reactive, ref, watch, onMounted, onUnmounted } from 'vue'
+import { useRouter, useNuxtApp, useHead } from '#imports'
+import { useLogoStore } from '~/stores/logoStores'
+import { useUserProfileStore } from '~/stores/userProfile'
+
+useHead({
+    title: 'Account Dashboard | Cyborg Logo'
+})
+
+const router = useRouter()
+const nuxtApp = useNuxtApp()
+const logoStore = useLogoStore()
+const profileStore = useUserProfileStore()
+
+const form = reactive({
+    firstName: '',
+    lastName: '',
+    phone: '',
+    email: '',
+})
+
+const feedback = reactive({
+    success: '',
+})
+
+const auth = nuxtApp.$firebase?.auth || null
+const listenAuthState = nuxtApp.$firebase?.onAuthStateChanged
+
+const currentUser = ref(auth?.currentUser || null)
+const isAuthChecking = ref(!currentUser.value)
+const logosLoading = ref(false)
+const unsubscribeAuth = ref(null)
+
+const normalizeDateValue = (value) => {
+    if (!value) return null
+    if (typeof value.toDate === 'function') {
+        try {
+            return value.toDate()
+        } catch (error) {
+            return null
+        }
+    }
+    if (value instanceof Date) return value
+    const parsed = new Date(value)
+    return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+const formatDisplayDate = (value) => {
+    if (!value) return 'just now'
+    try {
+        return new Intl.DateTimeFormat('en-US', {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+        }).format(value)
+    } catch (error) {
+        return value.toString()
+    }
+}
+
+const getLogoTitle = (logo) => (
+    logo?.state?.fullBusinessName ||
+    logo?.state?.companyName ||
+    logo?.state?.businessNameInitials ||
+    'Saved Logo'
+)
+
+const exportLogoState = (logo) => {
+    if (!logo?.state) return
+    const blob = new Blob([JSON.stringify(logo.state, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    const title = getLogoTitle(logo)
+        .replace(/[^a-z0-9-_]+/gi, '-')
+        .replace(/-{2,}/g, '-')
+        .replace(/^-|-$/g, '')
+    link.download = `${title || 'logo-settings'}.json`
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
+}
+
+const profileError = computed(() => profileStore.error)
+const isLoadingProfile = computed(() => profileStore.isLoading)
+const isSaving = computed(() => profileStore.isSaving)
+const lastSavedCopy = computed(() => {
+    if (!profileStore.lastSavedAt) return ''
+    return formatDisplayDate(profileStore.lastSavedAt)
+})
+
+const hasChanges = computed(() => {
+    const source = profileStore.profile || {}
+    return ['firstName', 'lastName', 'phone', 'email'].some((field) => (form[field] || '') !== (source[field] || ''))
+})
+
+const savedLogos = computed(() => logoStore.savedLogos || [])
+
+const formattedLogos = computed(() =>
+    savedLogos.value.map((logo) => ({
+        ...logo,
+        createdAtDate: normalizeDateValue(logo.createdAt),
+    }))
+)
+
+watch(
+    () => profileStore.profile,
+    (profile) => {
+        form.firstName = profile?.firstName || ''
+        form.lastName = profile?.lastName || ''
+        form.phone = profile?.phone || ''
+        form.email = profile?.email || ''
+    },
+    { immediate: true }
+)
+
+const resumeLogo = (logo) => {
+    if (!logo) return
+    logoStore.restoreLogo(logo)
+    router.push('/create-my-logo')
+}
+
+const loadDashboardData = async (user) => {
+    if (!user) {
+        currentUser.value = null
+        isAuthChecking.value = false
+        feedback.success = ''
+        profileStore.resetProfile()
+        logoStore.$patch({ savedLogos: [] })
+        return
+    }
+
+    currentUser.value = user
+    isAuthChecking.value = false
+    feedback.success = ''
+
+    try {
+        await profileStore.loadProfile(user.uid)
+    } catch (error) {
+        // Errors are captured in the store
+    }
+
+    logosLoading.value = true
+    try {
+        await logoStore.fetchSavedLogos()
+    } catch (error) {
+        console.error('Unable to load saved logos', error)
+    } finally {
+        logosLoading.value = false
+    }
+}
+
+onMounted(async () => {
+    if (auth?.currentUser) {
+        await loadDashboardData(auth.currentUser)
+    } else {
+        isAuthChecking.value = true
+    }
+
+    if (listenAuthState && auth) {
+        unsubscribeAuth.value = listenAuthState(auth, (user) => {
+            loadDashboardData(user)
+        })
+    } else {
+        isAuthChecking.value = false
+    }
+})
+
+onUnmounted(() => {
+    if (typeof unsubscribeAuth.value === 'function') {
+        unsubscribeAuth.value()
+    }
+})
+
+const handleSave = async () => {
+    feedback.success = ''
+
+    try {
+        await profileStore.saveProfile({ ...form })
+        if (!profileError.value) {
+            feedback.success = 'Profile updated successfully.'
+        }
+    } catch (error) {
+        // Error message is surfaced via profileError
+    }
+}
+</script>
+
+<style scoped>
+.dashboard-page {
+    background-image: linear-gradient(180deg, rgba(243, 244, 246, 0.85) 0%, rgba(255, 255, 255, 0.95) 100%);
+}
+</style>

--- a/plugins/firebase.client.js
+++ b/plugins/firebase.client.js
@@ -1,1 +1,136 @@
-// plugins/firebase.client.js// Remove the default import; use only named imports.import { defineNuxtPlugin } from '#app'import { initializeApp } from 'firebase/app'import { getAnalytics } from 'firebase/analytics'import {    getAuth,    GoogleAuthProvider,    FacebookAuthProvider,    TwitterAuthProvider,    signInWithPopup,    fetchSignInMethodsForEmail,    signOut,    signInWithEmailAndPassword,    createUserWithEmailAndPassword,    sendEmailVerification,    updateProfile,    sendPasswordResetEmail,    setPersistence,    browserLocalPersistence,    signInAnonymously,    onAuthStateChanged} from "firebase/auth";// Import Firestore functionsimport { getFirestore } from 'firebase/firestore'// Your Firebase configuration// const firebaseConfig = {//     apiKey: "AIzaSyBye7vNe4IrJK2txXryWe7tZYOK_aWPM34",//     authDomain: "cyborg-logo-firebase.firebaseapp.com",//     projectId: "cyborg-logo-firebase",//     storageBucket: "cyborg-logo-firebase.firebasestorage.app",//     messagingSenderId: "807095161618",//     appId: "1:807095161618:web:44446030ae72ac7a0c59cb",//     measurementId: "G-L11BDTF5HP"// };const firebaseConfig = {    apiKey: "AIzaSyBVju5vlPyeUWnU40U0j4YEVDC6wki_ij8",    authDomain: "cyborg-logo-llc.firebaseapp.com",    projectId: "cyborg-logo-llc",    storageBucket: "cyborg-logo-llc.firebasestorage.app",    messagingSenderId: "845130277679",    appId: "1:845130277679:web:7874ee8ddf681c711c37da",    measurementId: "G-NVYTZQPDTT"};// Initialize the Firebase appconst app = initializeApp(firebaseConfig)const analytics = getAnalytics(app)const auth = getAuth(app)const firebaseDatabase = getFirestore(app) // initialize Firestore// Set authentication persistence to local cachingsetPersistence(auth, browserLocalPersistence)    .then(() => {        console.log("Firebase persistence set to local.");    })    .catch((error) => {        console.error("Error setting persistence:", error);    });// log out userconst signUserOut = () => {    return signOut(auth)        .then(() => {            console.log("User signed out.");        })        .catch((error) => {            console.error("Error signing out:", error);        });};// signInAnonymously(auth)//     .then(() => {//         console.log("Signed in anonymously");//     })//     .catch((error) => {//         console.error("Anonymous sign-in failed:", error);//     });// Export the plugin using defineNuxtPluginexport default defineNuxtPlugin(() => {    // 1) Initialize    const app = initializeApp(firebaseConfig)    const analytics = getAnalytics(app)    const auth = getAuth(app)              // ← explicitly bind to our app    const db = getFirestore(app)    // 2) Persistence    setPersistence(auth, browserLocalPersistence)        .then(() => console.log("Firebase persistence set to local."))        .catch(console.error)    // 3) Sign-out helper    const signUserOut = () =>        signOut(auth)            .then(() => console.log("User signed out."))            .catch(console.error)    return {        provide: {            firebase: {                app,                analytics,                auth,                firebaseDatabase: db,                googleProvider:   new GoogleAuthProvider(),                facebookProvider: new FacebookAuthProvider(),                twitterProvider:  new TwitterAuthProvider(), // unused for email, but harmless to keep                signInWithPopup,                fetchSignInMethodsForEmail,                signOut,                signUserOut,                signInWithEmailAndPassword,                createUserWithEmailAndPassword,                sendEmailVerification,                updateProfile,                sendPasswordResetEmail,                browserLocalPersistence,                signInAnonymously,                onAuthStateChanged            }        }    }})
+// plugins/firebase.client.js
+
+// Remove the default import; use only named imports.
+import { defineNuxtPlugin } from '#app'
+import { initializeApp } from 'firebase/app'
+import { getAnalytics } from 'firebase/analytics'
+
+import {
+    getAuth,
+    GoogleAuthProvider,
+    FacebookAuthProvider,
+    TwitterAuthProvider,
+    signInWithPopup,
+    fetchSignInMethodsForEmail,
+    signOut,
+    signInWithEmailAndPassword,
+    createUserWithEmailAndPassword,
+    sendEmailVerification,
+    updateProfile,
+    sendPasswordResetEmail,
+    setPersistence,
+    browserLocalPersistence,
+    signInAnonymously,
+    onAuthStateChanged,
+    updateEmail
+
+} from "firebase/auth";
+
+// Import Firestore functions
+import { getFirestore } from 'firebase/firestore'
+
+
+// Your Firebase configuration
+// const firebaseConfig = {
+//     apiKey: "AIzaSyBye7vNe4IrJK2txXryWe7tZYOK_aWPM34",
+//     authDomain: "cyborg-logo-firebase.firebaseapp.com",
+//     projectId: "cyborg-logo-firebase",
+//     storageBucket: "cyborg-logo-firebase.firebasestorage.app",
+//     messagingSenderId: "807095161618",
+//     appId: "1:807095161618:web:44446030ae72ac7a0c59cb",
+//     measurementId: "G-L11BDTF5HP"
+// };
+
+const firebaseConfig = {
+    apiKey: "AIzaSyBVju5vlPyeUWnU40U0j4YEVDC6wki_ij8",
+    authDomain: "cyborg-logo-llc.firebaseapp.com",
+    projectId: "cyborg-logo-llc",
+    storageBucket: "cyborg-logo-llc.firebasestorage.app",
+    messagingSenderId: "845130277679",
+    appId: "1:845130277679:web:7874ee8ddf681c711c37da",
+    measurementId: "G-NVYTZQPDTT"
+};
+
+// Initialize the Firebase app
+const app = initializeApp(firebaseConfig)
+const analytics = getAnalytics(app)
+const auth = getAuth(app)
+const firebaseDatabase = getFirestore(app) // initialize Firestore
+
+// Set authentication persistence to local caching
+setPersistence(auth, browserLocalPersistence)
+    .then(() => {
+        console.log("Firebase persistence set to local.");
+    })
+    .catch((error) => {
+        console.error("Error setting persistence:", error);
+    });
+
+// log out user
+const signUserOut = () => {
+    return signOut(auth)
+        .then(() => {
+            console.log("User signed out.");
+        })
+        .catch((error) => {
+            console.error("Error signing out:", error);
+        });
+};
+
+// signInAnonymously(auth)
+//     .then(() => {
+//         console.log("Signed in anonymously");
+//     })
+//     .catch((error) => {
+//         console.error("Anonymous sign-in failed:", error);
+//     });
+
+
+
+// Export the plugin using defineNuxtPlugin
+export default defineNuxtPlugin(() => {
+    // 1) Initialize
+    const app = initializeApp(firebaseConfig)
+    const analytics = getAnalytics(app)
+    const auth = getAuth(app)              // ← explicitly bind to our app
+    const db = getFirestore(app)
+
+    // 2) Persistence
+    setPersistence(auth, browserLocalPersistence)
+        .then(() => console.log("Firebase persistence set to local."))
+        .catch(console.error)
+
+    // 3) Sign-out helper
+    const signUserOut = () =>
+        signOut(auth)
+            .then(() => console.log("User signed out."))
+            .catch(console.error)
+
+    return {
+        provide: {
+            firebase: {
+                app,
+                analytics,
+                auth,
+                firebaseDatabase: db,
+                googleProvider:   new GoogleAuthProvider(),
+                facebookProvider: new FacebookAuthProvider(),
+                twitterProvider:  new TwitterAuthProvider(), // unused for email, but harmless to keep
+                signInWithPopup,
+                fetchSignInMethodsForEmail,
+                signOut,
+                signUserOut,
+                signInWithEmailAndPassword,
+                createUserWithEmailAndPassword,
+                sendEmailVerification,
+                updateProfile,
+                sendPasswordResetEmail,
+                browserLocalPersistence,
+                signInAnonymously,
+                onAuthStateChanged,
+                updateEmail
+            }
+        }
+    }
+})
+// Remove the default import; use only named imports.import { defineNuxtPlugin } from '#app'import { initializeApp } from 'firebase/app'import { getAnalytics } from 'firebase/analytics'import {    getAuth,    GoogleAuthProvider,    FacebookAuthProvider,    TwitterAuthProvider,    signInWithPopup,    fetchSignInMethodsForEmail,    signOut,    signInWithEmailAndPassword,    createUserWithEmailAndPassword,    sendEmailVerification,    updateProfile,    sendPasswordResetEmail,    setPersistence,    browserLocalPersistence,    signInAnonymously,    onAuthStateChanged} from "firebase/auth";// Import Firestore functionsimport { getFirestore } from 'firebase/firestore'// Your Firebase configuration// const firebaseConfig = {//     apiKey: "AIzaSyBye7vNe4IrJK2txXryWe7tZYOK_aWPM34",//     authDomain: "cyborg-logo-firebase.firebaseapp.com",//     projectId: "cyborg-logo-firebase",//     storageBucket: "cyborg-logo-firebase.firebasestorage.app",//     messagingSenderId: "807095161618",//     appId: "1:807095161618:web:44446030ae72ac7a0c59cb",//     measurementId: "G-L11BDTF5HP"// };const firebaseConfig = {    apiKey: "AIzaSyBVju5vlPyeUWnU40U0j4YEVDC6wki_ij8",    authDomain: "cyborg-logo-llc.firebaseapp.com",    projectId: "cyborg-logo-llc",    storageBucket: "cyborg-logo-llc.firebasestorage.app",    messagingSenderId: "845130277679",    appId: "1:845130277679:web:7874ee8ddf681c711c37da",    measurementId: "G-NVYTZQPDTT"};// Initialize the Firebase appconst app = initializeApp(firebaseConfig)const analytics = getAnalytics(app)const auth = getAuth(app)const firebaseDatabase = getFirestore(app) // initialize Firestore// Set authentication persistence to local cachingsetPersistence(auth, browserLocalPersistence)    .then(() => {        console.log("Firebase persistence set to local.");    })    .catch((error) => {        console.error("Error setting persistence:", error);    });// log out userconst signUserOut = () => {    return signOut(auth)        .then(() => {            console.log("User signed out.");        })        .catch((error) => {            console.error("Error signing out:", error);        });};// signInAnonymously(auth)//     .then(() => {//         console.log("Signed in anonymously");//     })//     .catch((error) => {//         console.error("Anonymous sign-in failed:", error);//     });// Export the plugin using defineNuxtPluginexport default defineNuxtPlugin(() => {    // 1) Initialize    const app = initializeApp(firebaseConfig)    const analytics = getAnalytics(app)    const auth = getAuth(app)              // ← explicitly bind to our app    const db = getFirestore(app)    // 2) Persistence    setPersistence(auth, browserLocalPersistence)        .then(() => console.log("Firebase persistence set to local."))        .catch(console.error)    // 3) Sign-out helper    const signUserOut = () =>        signOut(auth)            .then(() => console.log("User signed out."))            .catch(console.error)    return {        provide: {            firebase: {                app,                analytics,                auth,                firebaseDatabase: db,                googleProvider:   new GoogleAuthProvider(),                facebookProvider: new FacebookAuthProvider(),                twitterProvider:  new TwitterAuthProvider(), // unused for email, but harmless to keep                signInWithPopup,                fetchSignInMethodsForEmail,                signOut,                signUserOut,                signInWithEmailAndPassword,                createUserWithEmailAndPassword,                sendEmailVerification,                updateProfile,                sendPasswordResetEmail,                browserLocalPersistence,                signInAnonymously,                onAuthStateChanged            }        }    }})

--- a/stores/userProfile.js
+++ b/stores/userProfile.js
@@ -1,0 +1,158 @@
+// /stores/userProfile.js
+import { defineStore } from 'pinia'
+import { useNuxtApp } from '#app'
+import {
+    doc,
+    getDoc,
+    setDoc,
+    serverTimestamp,
+} from 'firebase/firestore'
+
+const createEmptyProfile = () => ({
+    firstName: '',
+    lastName: '',
+    phone: '',
+    email: '',
+})
+
+export const useUserProfileStore = defineStore('userProfile', {
+    state: () => ({
+        profile: createEmptyProfile(),
+        isLoading: false,
+        isSaving: false,
+        error: null,
+        lastSavedAt: null,
+        hasExistingProfile: false,
+    }),
+
+    actions: {
+        resetProfile() {
+            this.profile = createEmptyProfile()
+            this.error = null
+            this.lastSavedAt = null
+            this.hasExistingProfile = false
+        },
+
+        async loadProfile(userId = null) {
+            const nuxtApp = useNuxtApp()
+            const { auth, firebaseDatabase } = nuxtApp.$firebase || {}
+            const activeUser = userId ? { uid: userId } : auth?.currentUser
+
+            if (!activeUser?.uid || !firebaseDatabase) {
+                this.resetProfile()
+                return
+            }
+
+            this.isLoading = true
+            this.error = null
+
+            try {
+                const profileRef = doc(firebaseDatabase, 'userProfiles', activeUser.uid)
+                const snapshot = await getDoc(profileRef)
+
+                if (snapshot.exists()) {
+                    const data = snapshot.data() || {}
+                    const normalized = {
+                        ...createEmptyProfile(),
+                        ...data,
+                    }
+
+                    this.profile = normalized
+                    this.hasExistingProfile = true
+
+                    const updatedAt = data.updatedAt?.toDate?.()
+                    const createdAt = data.createdAt?.toDate?.()
+                    this.lastSavedAt = updatedAt || createdAt || null
+                } else {
+                    const fallbackEmail = auth?.currentUser?.email || ''
+                    this.profile = {
+                        ...createEmptyProfile(),
+                        email: fallbackEmail,
+                    }
+                    this.hasExistingProfile = false
+                    this.lastSavedAt = null
+                }
+            } catch (error) {
+                console.error('Failed to load profile', error)
+                this.error = error?.message || 'Unable to load your profile right now.'
+                throw error
+            } finally {
+                this.isLoading = false
+            }
+        },
+
+        async saveProfile(updates = {}) {
+            const nuxtApp = useNuxtApp()
+            const firebase = nuxtApp.$firebase || {}
+            const { auth, firebaseDatabase, updateProfile, updateEmail } = firebase
+            const user = auth?.currentUser
+
+            if (!user?.uid || !firebaseDatabase) {
+                const error = new Error('You must be logged in to save your profile.')
+                this.error = error.message
+                throw error
+            }
+
+            this.isSaving = true
+            this.error = null
+
+            const mergedProfile = {
+                ...createEmptyProfile(),
+                ...this.profile,
+                ...updates,
+                email: updates.email ?? this.profile.email ?? user.email ?? '',
+            }
+
+            const payload = {
+                ...mergedProfile,
+                updatedAt: serverTimestamp(),
+            }
+
+            if (!this.hasExistingProfile) {
+                payload.createdAt = serverTimestamp()
+            }
+
+            try {
+                const profileRef = doc(firebaseDatabase, 'userProfiles', user.uid)
+                await setDoc(profileRef, payload, { merge: true })
+
+                const displayName = [mergedProfile.firstName, mergedProfile.lastName]
+                    .filter(Boolean)
+                    .join(' ')
+                    .trim()
+
+                if (displayName) {
+                    try {
+                        await updateProfile?.(user, { displayName })
+                    } catch (profileError) {
+                        console.warn('Unable to update display name', profileError)
+                    }
+                }
+
+                if (
+                    mergedProfile.email &&
+                    user.email &&
+                    mergedProfile.email !== user.email &&
+                    typeof updateEmail === 'function'
+                ) {
+                    try {
+                        await updateEmail(user, mergedProfile.email)
+                    } catch (emailError) {
+                        console.warn('Unable to update authentication email', emailError)
+                        this.error = this.error || emailError?.message || 'Unable to update email address.'
+                    }
+                }
+
+                this.profile = mergedProfile
+                this.hasExistingProfile = true
+                this.lastSavedAt = new Date()
+            } catch (error) {
+                console.error('Failed to save profile', error)
+                this.error = error?.message || 'Unable to save your profile right now.'
+                throw error
+            } finally {
+                this.isSaving = false
+            }
+        },
+    },
+})


### PR DESCRIPTION
## Summary
- add a dedicated dashboard page with a profile form and saved logo management
- create a Pinia store to load and persist user profile details to Firestore
- expose Firebase `updateEmail` so profile updates can modify the auth email when possible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68f51248e414832db5412088b7739292